### PR TITLE
Set the correct category name

### DIFF
--- a/dropbox/__init__.py
+++ b/dropbox/__init__.py
@@ -22,7 +22,7 @@ CONFIG = {
             "dependencies": ["token"]
         }
     ],
-    "categories": [ "API" ],
+    "categories": [ "APIS" ],
     "keywords": [ "events", "team", "audit" ],
     "createdAt": "2016-10-21"
 }


### PR DESCRIPTION
`APIS` instead of `API`

@avinoamr 